### PR TITLE
新增auth命令支持独立配置身份认证

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ gal code
 
 - **首次运行** 会触发向导，要求填写 baseURL、model 与 apiKey，并写入 `~/.gemini-any-llm/config.yaml`。
 - 程序会自动生成或更新 `~/.gemini/settings.json`，确保 `selectedAuthType` 固定为 `gemini-api-key`。
+- 需要重新配置或切换鉴权时，执行 `gal auth` 可重新运行向导并刷新认证设置。
 - 完成配置后，每次执行 `gal code` 即可自动连接网关并调用 Gemini CLI。
 
 ## 📖 使用指南

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "test:e2e": "jest --config ./test/jest-e2e.json",
     "gal:code": "pnpm run build && node dist/cli/gal.js code",
     "gal:code:dev": "node --require ts-node/register/transpile-only src/cli/gal.ts code",
+    "gal:auth:dev": "node --require ts-node/register/transpile-only src/cli/gal.ts auth",
     "prepublishOnly": "pnpm run build",
     "ps": "pnpm publish --registry https://registry.npmjs.org"
   },

--- a/src/cli/gal-auth.ts
+++ b/src/cli/gal-auth.ts
@@ -1,0 +1,27 @@
+import * as os from 'os';
+import * as path from 'path';
+import { GlobalConfigService } from '../config/global-config.service';
+import { ensureGeminiSettings, runConfigWizard } from './gal-code';
+
+export async function runGalAuth(): Promise<void> {
+  const configDir = path.join(os.homedir(), '.gemini-any-llm');
+  const configFile = path.join(configDir, 'config.yaml');
+
+  ensureGeminiSettings();
+  await runConfigWizard(configFile);
+
+  const configService = new GlobalConfigService();
+  const result = configService.loadGlobalConfig();
+  if (!result.isValid) {
+    console.error('配置校验失败，请检查 ~/.gemini-any-llm/config.yaml。');
+    result.errors?.forEach((error) => {
+      if (error?.message) {
+        console.error(`- ${error.message}`);
+      }
+    });
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log('认证配置已更新。');
+}

--- a/src/cli/gal-code.ts
+++ b/src/cli/gal-code.ts
@@ -86,7 +86,7 @@ function shouldRunWizard(
   return !result.isValid && Boolean(hasCriticalError);
 }
 
-async function runConfigWizard(configFile: string): Promise<void> {
+export async function runConfigWizard(configFile: string): Promise<void> {
   ensureDir(path.dirname(configFile));
 
   let existingConfig: any = {};
@@ -522,7 +522,7 @@ async function launchGeminiCLI(
   });
 }
 
-function ensureGeminiSettings(): void {
+export function ensureGeminiSettings(): void {
   const settingsDir = path.join(os.homedir(), '.gemini');
   const settingsFile = path.join(settingsDir, 'settings.json');
 

--- a/src/cli/gal.ts
+++ b/src/cli/gal.ts
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 import { runGalCode } from './gal-code';
+import { runGalAuth } from './gal-auth';
 
 const [, , command, ...restArgs] = process.argv;
 
-const HELP_TEXT = `\nUsage: gal [command]\n\nCommands:\n  code          启动/连接网关并调用 gemini CLI\n  -h, --help    查看帮助\n\n示例:\n  gal code "请用TypeScript写一个HTTP服务"\n`;
+const HELP_TEXT = `\nUsage: gal [command]\n\nCommands:\n  code          启动/连接网关并调用 gemini CLI\n  auth          配置 Gemini CLI 身份认证\n  -h, --help    查看帮助\n\n示例:\n  gal code "请用TypeScript写一个HTTP服务"\n`;
 
 function showHelp() {
   console.log(HELP_TEXT);
@@ -18,6 +19,9 @@ async function main() {
   switch (command) {
     case 'code':
       await runGalCode(restArgs);
+      break;
+    case 'auth':
+      await runGalAuth();
       break;
     default:
       console.log(`未知命令: ${command}`);


### PR DESCRIPTION
  - 新增gal-auth.ts实现认证配置逻辑
  - 在gal.ts中添加auth命令支持
  - 导出gal-code.ts中的配置函数供复用
  - 添加gal:auth:dev开发脚本
  - 更新README.md说明auth命令用法